### PR TITLE
fix: text selection color

### DIFF
--- a/themes/tokyo-night.json
+++ b/themes/tokyo-night.json
@@ -141,7 +141,7 @@
           {
             "cursor": "#7c7f93",
             "background": "#7c7f93",
-            "selection": "#7c7f93"
+            "selection": "#267ead3d"
           }
         ],
         "syntax": {
@@ -446,7 +446,7 @@
           {
             "cursor": "#7c7f93",
             "background": "#7c7f93",
-            "selection": "#7c7f93"
+            "selection": "#267ead3d"
           }
         ],
         "syntax": {
@@ -751,7 +751,7 @@
           {
             "cursor": "#7c7f93",
             "background": "#7c7f93",
-            "selection": "#7c7f93"
+            "selection": "#267ead3d"
           }
         ],
         "syntax": {


### PR DESCRIPTION
The previous selection color: #7c7f93 would render text unreadable when text is selected on LSP/Intellisense hover.

![selection-color-on-code-hover](https://github.com/user-attachments/assets/e4fd1b8e-f245-456e-bdb1-af1b09281be4)
