### PR TITLE
Add Moon theme variant

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "tokyo-night"
 name = "Tokyo Night Themes"
-version = "0.6.0"
+version = "0.7.0"
 schema_version = 1
 authors = ["ssaunderss <austinsaunders@me.com>"]
 description = "Tokyo Night Themes"

--- a/themes/tokyo-night.json
+++ b/themes/tokyo-night.json
@@ -1926,6 +1926,641 @@
           }
         }
       }
+    },
+    {
+      "name": "Tokyo Night Moon",
+      "appearance": "dark",
+      "style": {
+        "accents": [
+          "#c099ff66",
+          "#82aaff66",
+          "#c3e88d66",
+          "#4fd6be66",
+          "#ffc77766",
+          "#ff966c66",
+          "#ff757f66"
+        ],
+        "background.appearance": "opaque",
+        "border": "#1b1e2e",
+        "border.variant": "#1b1e2e",
+        "border.focused": "#86e1fc33",
+        "border.selected": "#1b1e2e",
+        "border.transparent": "#1b1e2e",
+        "border.disabled": "#1b1e2e",
+        "elevated_surface.background": "#1b1e2e",
+        "surface.background": "#1e2030",
+        "background": "#222436",
+        "element.background": "#222436",
+        "element.hover": "#636da6",
+        "element.active": "#9aa5ce",
+        "element.selected": "#636da6",
+        "element.disabled": "#444a73",
+        "drop_target.background": "#1e202e",
+        "ghost_element.background": "#222436",
+        "ghost_element.hover": "#636da6",
+        "ghost_element.active": "#9aa5ce",
+        "ghost_element.selected": "#636da6",
+        "ghost_element.disabled": "#444a73",
+        "text": "#828bb8",
+        "text.muted": "#7982a9",
+        "text.placeholder": "#787c99",
+        "text.disabled": "#444a73",
+        "text.accent": "#86e1fc",
+        "icon": "#787c99",
+        "icon.muted": "#787c99",
+        "icon.disabled": "#444a73",
+        "icon.placeholder": "#636da6",
+        "icon.accent": "#86e1fc",
+        "status_bar.background": "#1e2030",
+        "title_bar.background": "#1e2030",
+        "title_bar.inactive_background": "#1e2030",
+        "toolbar.background": "#1e2030",
+        "tab_bar.background": "#1e2030",
+        "tab.inactive_background": "#1e2030",
+        "tab.active_background": "#444a73",
+        "search.match_background": "#444a73",
+        "panel.background": "#1e2030",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.background": "#444a7380",
+        "scrollbar.thumb.hover_background": "#444a73",
+        "scrollbar.thumb.border": "#444a73",
+        "scrollbar.track.background": "#22243680",
+        "scrollbar.track.border": "#1b1e2e",
+        "editor.foreground": "#828bb8",
+        "editor.background": "#222436",
+        "editor.gutter.background": "#222436",
+        "editor.subheader.background": "#222436",
+        "editor.active_line.background": "#2f334d",
+        "editor.highlighted_line.background": "#1e202e",
+        "editor.line_number": "#3b4261",
+        "editor.active_line_number": "#828bb8",
+        "editor.invisible": null,
+        "editor.wrap_guide": "#1b1e2e",
+        "editor.active_wrap_guide": "#1b1e2e",
+        "editor.document_highlight.read_background": "#363b54",
+        "editor.document_highlight.write_background": "#363b54",
+        "terminal.background": "#1e2030",
+        "terminal.foreground": null,
+        "terminal.bright_foreground": null,
+        "terminal.dim_foreground": null,
+        "terminal.ansi.black": "#444a73",
+        "terminal.ansi.bright_black": "#444a73",
+        "terminal.ansi.dim_black": null,
+        "terminal.ansi.red": "#ff757f",
+        "terminal.ansi.bright_red": "#ff757f",
+        "terminal.ansi.dim_red": null,
+        "terminal.ansi.green": "#4fd6be",
+        "terminal.ansi.bright_green": "#4fd6be",
+        "terminal.ansi.dim_green": null,
+        "terminal.ansi.yellow": "#ffc777",
+        "terminal.ansi.bright_yellow": "#ffc777",
+        "terminal.ansi.dim_yellow": null,
+        "terminal.ansi.blue": "#82aaff",
+        "terminal.ansi.bright_blue": "#82aaff",
+        "terminal.ansi.dim_blue": null,
+        "terminal.ansi.magenta": "#c099ff",
+        "terminal.ansi.bright_magenta": "#c099ff",
+        "terminal.ansi.dim_magenta": null,
+        "terminal.ansi.cyan": "#86e1fc",
+        "terminal.ansi.bright_cyan": "#86e1fc",
+        "terminal.ansi.dim_cyan": null,
+        "terminal.ansi.white": "#7982a9",
+        "terminal.ansi.bright_white": "#828bb8",
+        "terminal.ansi.dim_white": null,
+        "link_text.hover": "#86e1fc",
+        "conflict": "#c099ff",
+        "conflict.background": "#222436",
+        "conflict.border": "#444a73",
+        "created": "#c3e88d",
+        "created.background": "#222436",
+        "created.border": "#444a73",
+        "deleted": "#ff757f",
+        "deleted.background": "#222436",
+        "deleted.border": "#444a73",
+        "error": "#ff757f",
+        "error.background": "#222436",
+        "error.border": "#444a73",
+        "hidden": "#787c99",
+        "hidden.background": "#222436",
+        "hidden.border": "#444a73",
+        "hint": "#636da6",
+        "hint.background": "#222436",
+        "hint.border": "#444a73",
+        "ignored": "#515670",
+        "ignored.background": "#222436",
+        "ignored.border": "#444a73",
+        "info": "#0da0ba",
+        "info.background": "#222436",
+        "info.border": "#444a73",
+        "modified": "#ffc777",
+        "modified.background": "#222436",
+        "modified.border": "#444a73",
+        "predictive": "#636da6",
+        "predictive.background": "#222436",
+        "predictive.border": "#444a73",
+        "renamed": "#c3e88d",
+        "renamed.background": "#222436",
+        "renamed.border": "#444a73",
+        "success": "#c3e88d",
+        "success.background": "#222436",
+        "success.border": "#444a73",
+        "unreachable": "#ff757f",
+        "unreachable.background": "#222436",
+        "unreachable.border": "#444a73",
+        "warning": "#ffc777",
+        "warning.background": "#222436",
+        "warning.border": "#444a73",
+        "players": [
+          {
+            "cursor": "#7c7f93",
+            "background": "#7c7f93",
+            "selection": "#267ead3d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#ff966c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#636da6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#636da6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#ff966c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#ff757f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#ff757f",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#ff757f",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "function": {
+            "color": "#82aaff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#4fd6be",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#4fd6be",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#ff966c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#4fd6be",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#ff757f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#ff966c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type": {
+            "color": "#65bcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#ff757f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "character": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "character.special": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.documentation": {
+            "color": "#636da6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.error": {
+            "color": "#ff757f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.hint": {
+            "color": "#0da0ba",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.note": {
+            "color": "#86e1fc",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.todo": {
+            "color": "#ffc777",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.warning": {
+            "color": "#ffc777",
+            "font_style": null,
+            "font_weight": null
+          },
+          "concept": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.builtin": {
+            "color": "#ff966c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.macro": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "diff.minus": {
+            "color": "#ff757f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "diff.plus": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "enum": {
+            "color": "#65bcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "field": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "float": {
+            "color": "#ff966c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.builtin": {
+            "color": "#82aaff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.call": {
+            "color": "#82aaff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.decorator": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.macro": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#82aaff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method.call": {
+            "color": "#82aaff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional.ternary": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.coroutine": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.debug": {
+            "color": "#ff757f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive.define": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.exception": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.export": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.function": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.import": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.modifier": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.operator": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.repeat": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.return": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.type": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "module": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number.float": {
+            "color": "#ff966c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "parameter": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "parent": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predoc": {
+            "color": "#636da6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.doc": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.documentation": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regexp": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.path": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.url": {
+            "color": "#86e1fc",
+            "font_style": null,
+            "font_weight": null
+          },
+          "symbol": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.attribute": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.delimiter": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.doctype": {
+            "color": "#636da6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#65bcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.class.definition": {
+            "color": "#65bcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.definition": {
+            "color": "#65bcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.interface": {
+            "color": "#65bcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.super": {
+            "color": "#65bcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.builtin": {
+            "color": "#ff757f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.member": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
This adds the Moon theme variant from [Folke's Tokyo Night Neovim port](https://github.com/folke/tokyonight.nvim/tree/main).

This fixes #12 

To fix, I did a find replace of Folke's Storm variables to their Moon equivalents against this repo's Storm implementation (see table below). 
The only discrepancy I found was that this repo’s Storm comment color (#5f6996) differs from Folke’s (#565f89). For this pull requests Moon comment color, I used Folke’s Moon comment value (#636da6).

| Variable               | Folke Storm   | Folke Moon    |
|----------------|---------|---------|
| bg             | #24283b | #222436 |
| bg_dark        | #1f2335 | #1e2030 |
| bg_dark1       | #1b1e2d | #191B29 |
| bg_highlight   | #292e42 | #2f334d |
| blue           | #7aa2f7 | #82aaff |
| blue0          | #3d59a1 | #3e68d7 |
| blue1          | #2ac3de | #65bcff |
| blue2          | #0db9d7 | #0db9d7 |
| blue5          | #89ddff | #89ddff |
| blue6          | #b4f9f8 | #b4f9f8 |
| blue7          | #394b70 | #394b70 |
| comment        | #565f89 | #636da6 |
| cyan           | #7dcfff | #86e1fc |
| dark3          | #545c7e | #545c7e |
| dark5          | #737aa2 | #737aa2 |
| fg             | #c0caf5 | #c8d3f5 |
| fg_dark        | #a9b1d6 | #828bb8 |
| fg_gutter      | #3b4261 | #3b4261 |
| green          | #9ece6a | #c3e88d |
| green1         | #73daca | #4fd6be |
| green2         | #41a6b5 | #41a6b5 |
| magenta        | #bb9af7 | #c099ff |
| magenta2       | #ff007c | #ff007c |
| orange         | #ff9e64 | #ff966c |
| purple         | #9d7cd8 | #fca7ea |
| red            | #f7768e | #ff757f |
| red1           | #db4b4b | #c53b53 |
| teal           | #1abc9c | #4fd6be |
| terminal_black | #414868 | #444a73 |
| yellow         | #e0af68 | #ffc777 |